### PR TITLE
Switch share and shareinclude

### DIFF
--- a/commands/artworks.go
+++ b/commands/artworks.go
@@ -75,9 +75,9 @@ func artworksGroup(b *bot.Bot) {
 	b.Router.RegisterCmd(&gumi.Command{
 		Name:        "share",
 		Group:       group,
-		Aliases:     []string{"pixiv", "twitter", "exclude"},
-		Description: "Shares an artwork from a URL, optionally excludes images.",
-		Usage:       "bt!share <artwork url> [indices to exclude]",
+		Aliases:     []string{"pixiv", "twitter", "include", "si"},
+		Description: "Shares an artwork from a URL, optionally includes some images.",
+		Usage:       "bt!share <artwork url> [indices to include]",
 		Example:     "bt!share https://pixiv.net/artworks/86341538 1-3 5",
 		GuildOnly:   true,
 		RateLimiter: gumi.NewRateLimiter(5 * time.Second),
@@ -85,15 +85,15 @@ func artworksGroup(b *bot.Bot) {
 	})
 
 	b.Router.RegisterCmd(&gumi.Command{
-		Name:        "shareinclude",
+		Name:        "shareexclude",
 		Group:       group,
-		Aliases:     []string{"si", "include"},
-		Description: "Shares an artwork from a URL, optionally include only some images.",
-		Usage:       "bt!si <artwork url> [indices to include]",
-		Example:     "bt!si https://pixiv.net/artworks/86341538 1",
+		Aliases:     []string{"exclude", "ex"},
+		Description: "Shares an artwork from a URL, optionally excludes some images.",
+		Usage:       "bt!ex <artwork url> [indices to exclude]",
+		Example:     "bt!ex https://pixiv.net/artworks/86341538 1",
 		GuildOnly:   true,
 		RateLimiter: gumi.NewRateLimiter(5 * time.Second),
-		Exec:        shareInclude(b),
+		Exec:        shareExclude(b),
 	})
 
 	b.Router.RegisterCmd(&gumi.Command{
@@ -186,7 +186,7 @@ func share(b *bot.Bot) func(ctx *gumi.Ctx) error {
 
 		p := post.New(b, ctx, url)
 		if len(indices) > 0 {
-			p.SetSkip(indices, post.SkipModeExclude)
+			p.SetSkip(indices, post.SkipModeInclude)
 		}
 
 		allSent := make([]*cache.MessageInfo, 0)
@@ -232,7 +232,7 @@ func share(b *bot.Bot) func(ctx *gumi.Ctx) error {
 	}
 }
 
-func shareInclude(b *bot.Bot) func(ctx *gumi.Ctx) error {
+func shareExclude(b *bot.Bot) func(ctx *gumi.Ctx) error {
 	return func(ctx *gumi.Ctx) error {
 		if ctx.Args.Len() < 1 {
 			return messages.ErrIncorrectCmd(ctx.Command)
@@ -261,7 +261,7 @@ func shareInclude(b *bot.Bot) func(ctx *gumi.Ctx) error {
 
 		p := post.New(b, ctx, url)
 		if len(indices) > 0 {
-			p.SetSkip(indices, post.SkipModeInclude)
+			p.SetSkip(indices, post.SkipModeExclude)
 		}
 
 		allSent := make([]*cache.MessageInfo, 0)


### PR DESCRIPTION
Switched the share() and shareInclude() functions and commands to share() and shareExclude().
Modified command  descriptions.
share and shareExclude has the following Aliases:

- pixiv, twitter, include, si
- exclude, ex