### PR TITLE
Artwork files cleanup

### DIFF
--- a/artworks/artworks.go
+++ b/artworks/artworks.go
@@ -1,19 +1,84 @@
 package artworks
 
 import (
+	"net/url"
+	"regexp"
+	"strconv"
+	"strings"
 	"github.com/VTGare/boe-tea-go/store"
 	"github.com/bwmarrin/discordgo"
 )
 
 type Provider interface {
-	Match(url string) (string, bool)
-	Find(id string) (Artwork, error)
+    Match(string) (string, bool)
+	Find(string) (Artwork, error)
 	Enabled(*store.Guild) bool
+	IsTwitter() bool
 }
 
 type Artwork interface {
-	StoreArtwork() *store.Artwork
-	MessageSends(footer string, tags bool) ([]*discordgo.MessageSend, error)
-	URL() string
+	StoreArtwork(string, string, string, []string) *store.Artwork
+	MessageSends(string, bool) ([]*discordgo.MessageSend, error)
+	GetTitle() string
+	GetAuthor() string
+	GetURL() string
+	GetImages() []string
 	Len() int
 }
+
+type ProvBase struct { Regex *regexp.Regexp }
+type TwitBase struct {}
+type ArtBase struct {}
+
+func (p *ProvBase) Match(url string) (string, bool) {
+	res := p.Regex.FindStringSubmatch(url)
+	if res == nil {
+		return "", false
+	}
+	return res[1], true
+}
+
+func (t *TwitBase) Match(s string) (string, bool) {
+	u, err := url.ParseRequestURI(s)
+	if err != nil {
+		return "", false
+	}
+
+	if u.Host != "twitter.com" && u.Host != "mobile.twitter.com" {
+		return "", false
+	}
+
+	parts := strings.FieldsFunc(u.Path, func(r rune) bool {
+		return r == '/'
+	})
+
+	if len(parts) < 3 {
+		return "", false
+	}
+
+	parts = parts[2:]
+	if parts[0] == "status" {
+		parts = parts[1:]
+	}
+
+	snowflake := parts[0]
+	if _, err := strconv.ParseUint(snowflake, 10, 64); err != nil {
+		return "", false
+	}
+
+	return snowflake, true
+}
+
+//StoreArtwork transforms an artwork to an insertable to database artwork model.
+func (a *ArtBase) StoreArtwork(title string, author string, url string, images []string) *store.Artwork {
+    return &store.Artwork{
+        Title:  title,
+        Author: author,
+        URL:    url,
+        Images: images,
+    }
+}
+
+func (p *ProvBase) IsTwitter() bool { return false }
+func (t *TwitBase) IsTwitter() bool { return true }
+func (a *ArtBase) GetTitle() string { return "" }

--- a/artworks/deviant/deviant.go
+++ b/artworks/deviant/deviant.go
@@ -19,10 +19,11 @@ import (
 )
 
 type DeviantArt struct {
-	regex *regexp.Regexp
+    artworks.ProvBase
 }
 
 type Artwork struct {
+    artworks.ArtBase
 	Title        string
 	Author       *Author
 	ImageURL     string
@@ -63,9 +64,9 @@ type deviantEmbed struct {
 }
 
 func New() artworks.Provider {
-	return &DeviantArt{
-		regex: regexp.MustCompile(`(?i)https:\/\/(?:www\.)?deviantart\.com\/[\w]+\/art\/([\w\-]+)`),
-	}
+    prov := artworks.ProvBase{}
+    prov.Regex = regexp.MustCompile(`(?i)https:\/\/(?:www\.)?deviantart\.com\/[\w]+\/art\/([\w\-]+)`)
+	return &DeviantArt{prov}
 }
 
 func (d *DeviantArt) Find(id string) (artworks.Artwork, error) {
@@ -97,15 +98,6 @@ func (d *DeviantArt) Find(id string) (artworks.Artwork, error) {
 		CreatedAt:    res.Pubdate,
 		url:          res.AuthorURL + "/art/" + id,
 	}, nil
-}
-
-func (d *DeviantArt) Match(s string) (string, bool) {
-	res := d.regex.FindStringSubmatch(s)
-	if res == nil {
-		return "", false
-	}
-
-	return res[1], true
 }
 
 func (d *DeviantArt) Enabled(g *store.Guild) bool {
@@ -141,19 +133,8 @@ func (a *Artwork) MessageSends(footer string, hasTags bool) ([]*discordgo.Messag
 	}, nil
 }
 
-func (a *Artwork) StoreArtwork() *store.Artwork {
-	return &store.Artwork{
-		Title:  a.Title,
-		Author: a.Author.Name,
-		URL:    a.url,
-		Images: []string{a.ImageURL},
-	}
-}
-
-func (a *Artwork) URL() string {
-	return a.url
-}
-
-func (a *Artwork) Len() int {
-	return 1
-}
+func (a *Artwork) GetTitle() string { return a.Title }
+func (a *Artwork) GetAuthor() string { return a.Author.Name }
+func (a *Artwork) GetURL() string { return a.url }
+func (a *Artwork) GetImages() []string { return []string{a.ImageURL} }
+func (a *Artwork) Len() int { return 1 }

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -382,9 +382,11 @@ func OnReactionAdd(b *bot.Bot) func(*discordgo.Session, *discordgo.MessageReacti
 				return nil
 			}
 
-			artworkDB, err := b.Store.Artwork(ctx, 0, artwork.URL())
+			artworkDB, err := b.Store.Artwork(ctx, 0, artwork.GetURL())
 			if errors.Is(err, store.ErrArtworkNotFound) {
-				artworkDB, err = b.Store.CreateArtwork(ctx, artwork.StoreArtwork())
+				artworkDB, err = b.Store.CreateArtwork(ctx, artwork.StoreArtwork(
+				    artwork.GetTitle(), artwork.GetAuthor(), artwork.GetURL(), artwork.GetImages(),
+				))
 			}
 
 			if err != nil {
@@ -541,7 +543,7 @@ func OnReactionRemove(b *bot.Bot) func(*discordgo.Session, *discordgo.MessageRea
 			return
 		}
 
-		artworkDB, err := b.Store.Artwork(ctx, 0, artwork.URL())
+		artworkDB, err := b.Store.Artwork(ctx, 0, artwork.GetURL())
 		if err != nil {
 			if !errors.Is(err, mongo.ErrNoDocuments) {
 				log.With("error", err).Error("failed to find an artwork")


### PR DESCRIPTION
Cleaned up and modified the following files to demonstrate inheritance through embedded structs, removed repeated code, adjusted functions for repeated use. This shouldn't impact the original functionality of boe-tea-go:

- artworks.go
- handlers.go
- artstation.go
- deviant.go
- pixiv.go
- twitter.go
- nitter.go