### PR TITLE
fix: Pixiv error embeds now expire

### DIFF
--- a/artworks/pixiv/pixiv.go
+++ b/artworks/pixiv/pixiv.go
@@ -96,8 +96,6 @@ func (p *Pixiv) _find(id string) (artworks.Artwork, error) {
 		return nil, artworks.ErrArtworkNotFound
 	}
 
-	fmt.Printf("%+v\n", illust)
-
 	author := ""
 	if illust.User != nil {
 		author = illust.User.Name
@@ -155,9 +153,6 @@ func (p *Pixiv) _find(id string) (artworks.Artwork, error) {
 
 		proxy: p.proxyHost,
 	}
-
-	fmt.Printf("%+v\n", artwork)
-	fmt.Printf("%+v\n", artwork.Images[0])
 
 	if artwork.Images[0].Original == "https://s.pximg.net/common/images/limit_sanity_level_360.png" {
 		return nil, artworks.ErrRateLimited

--- a/artworks/pixiv/pixiv.go
+++ b/artworks/pixiv/pixiv.go
@@ -96,6 +96,8 @@ func (p *Pixiv) _find(id string) (artworks.Artwork, error) {
 		return nil, artworks.ErrArtworkNotFound
 	}
 
+	fmt.Printf("%+v\n", illust)
+
 	author := ""
 	if illust.User != nil {
 		author = illust.User.Name
@@ -152,6 +154,13 @@ func (p *Pixiv) _find(id string) (artworks.Artwork, error) {
 		CreatedAt: illust.CreateDate,
 
 		proxy: p.proxyHost,
+	}
+
+	fmt.Printf("%+v\n", artwork)
+	fmt.Printf("%+v\n", artwork.Images[0])
+
+	if artwork.Images[0].Original == "https://s.pximg.net/common/images/limit_sanity_level_360.png" {
+		return nil, artworks.ErrRateLimited
 	}
 
 	if illust.IllustAIType == pixiv.IllustAITypeAIGenerated {

--- a/commands/user.go
+++ b/commands/user.go
@@ -401,6 +401,7 @@ func push(b *bot.Bot) func(ctx *gumi.Ctx) error {
 	}
 }
 
+// remove deletes one or more crosspost channels from a group.
 func remove(b *bot.Bot) func(ctx *gumi.Ctx) error {
 	return func(ctx *gumi.Ctx) error {
 		user, err := initCommand(b, ctx, 2)

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -600,6 +600,7 @@ func OnError(b *bot.Bot) func(*gumi.Ctx, error) {
 			cmdErr     *messages.IncorrectCmd
 			usrErr     *messages.UserErr
 			artworkErr *artworks.Error
+			expiry     bool = false
 		)
 
 		switch {
@@ -609,6 +610,7 @@ func OnError(b *bot.Bot) func(*gumi.Ctx, error) {
 			eb = onUserError(b, ctx, usrErr)
 		case errors.As(err, &artworkErr):
 			eb = onArtworkError(b, ctx, artworkErr)
+			expiry = true
 		default:
 			eb = onDefaultError(b, ctx, err)
 		}
@@ -617,8 +619,19 @@ func OnError(b *bot.Bot) func(*gumi.Ctx, error) {
 			return
 		}
 
-		if err := ctx.ReplyEmbed(eb.Finalize()); err != nil {
+		msg, err := ctx.Session.ChannelMessageSendEmbedReply(ctx.Event.ChannelID, eb.Finalize(),
+			&discordgo.MessageReference{
+				MessageID: ctx.Event.ID,
+				ChannelID: ctx.Event.ChannelID,
+				GuildID:   ctx.Event.GuildID,
+			})
+		if err != nil {
 			b.Log.With("error", err).Error("failed to reply in error handler")
+		}
+
+		if expiry {
+			warning := "failed to delete an error message"
+			messages.ExpireMessage(b, ctx.Session, msg, warning)
 		}
 	}
 }

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -12,6 +12,7 @@ import (
 	"github.com/VTGare/boe-tea-go/bot"
 	"github.com/VTGare/boe-tea-go/internal/arrays"
 	"github.com/VTGare/boe-tea-go/internal/cache"
+	"github.com/VTGare/boe-tea-go/internal/dgoutils"
 	"github.com/VTGare/boe-tea-go/messages"
 	"github.com/VTGare/boe-tea-go/post"
 	"github.com/VTGare/boe-tea-go/store"
@@ -630,8 +631,7 @@ func OnError(b *bot.Bot) func(*gumi.Ctx, error) {
 		}
 
 		if expiry {
-			warning := "failed to delete an error message"
-			messages.ExpireMessage(b, ctx.Session, msg, warning)
+			dgoutils.ExpireMessage(b, ctx.Session, msg)
 		}
 	}
 }

--- a/internal/dgoutils/dgoutils.go
+++ b/internal/dgoutils/dgoutils.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/VTGare/boe-tea-go/bot"
 	"github.com/VTGare/gumi"
 	"github.com/bwmarrin/discordgo"
 )
@@ -31,6 +32,24 @@ func TrimUserMention(ctx *gumi.Ctx, n int) string {
 	}
 
 	return ctx.Args.Get(n).Raw
+}
+
+// Deletes a specified message after a certain time
+func ExpireMessage(b *bot.Bot, s *discordgo.Session, msg *discordgo.Message) {
+	go func() {
+		time.Sleep(15 * time.Second)
+		err := s.ChannelMessageDelete(msg.ChannelID, msg.ID)
+		if err != nil {
+			log := b.Log.With(
+				"guild_id", msg.GuildID,
+				"channel_id", msg.ChannelID,
+				"message_id", msg.ID,
+				"error", err,
+			)
+
+			log.Warn("failed to expire message")
+		}
+	}()
 }
 
 func MemberHasPermission(s *discordgo.Session, guildID string, userID string, permission int64) (bool, error) {

--- a/messages/messages.go
+++ b/messages/messages.go
@@ -5,7 +5,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/VTGare/boe-tea-go/bot"
 	"github.com/VTGare/boe-tea-go/internal/arrays"
+	"github.com/bwmarrin/discordgo"
 )
 
 func FormatBool(b bool) string {
@@ -93,6 +95,24 @@ func FormatDuration(d time.Duration) string {
 
 	sb.WriteString(fmt.Sprintf("%02d seconds", seconds))
 	return sb.String()
+}
+
+// Deletes a specified message after a certain time
+func ExpireMessage(b *bot.Bot, s *discordgo.Session, msg *discordgo.Message, warning string) {
+	go func() {
+		time.Sleep(15 * time.Second)
+		err := s.ChannelMessageDelete(msg.ChannelID, msg.ID)
+		if err != nil {
+			log := b.Log.With(
+				"guild_id", msg.GuildID,
+				"channel_id", msg.ChannelID,
+				"message_id", msg.ID,
+				"error", err,
+			)
+
+			log.Warn(warning)
+		}
+	}()
 }
 
 // Returns a Discord relative timestamp

--- a/messages/messages.go
+++ b/messages/messages.go
@@ -5,9 +5,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/VTGare/boe-tea-go/bot"
 	"github.com/VTGare/boe-tea-go/internal/arrays"
-	"github.com/bwmarrin/discordgo"
 )
 
 func FormatBool(b bool) string {
@@ -95,24 +93,6 @@ func FormatDuration(d time.Duration) string {
 
 	sb.WriteString(fmt.Sprintf("%02d seconds", seconds))
 	return sb.String()
-}
-
-// Deletes a specified message after a certain time
-func ExpireMessage(b *bot.Bot, s *discordgo.Session, msg *discordgo.Message, warning string) {
-	go func() {
-		time.Sleep(15 * time.Second)
-		err := s.ChannelMessageDelete(msg.ChannelID, msg.ID)
-		if err != nil {
-			log := b.Log.With(
-				"guild_id", msg.GuildID,
-				"channel_id", msg.ChannelID,
-				"message_id", msg.ID,
-				"error", err,
-			)
-
-			log.Warn(warning)
-		}
-	}()
 }
 
 // Returns a Discord relative timestamp

--- a/post/post.go
+++ b/post/post.go
@@ -376,8 +376,7 @@ func (p *Post) sendReposts(reposts []*repost.Repost) error {
 		return fmt.Errorf("failed to send message to discord: %w", err)
 	}
 
-	warning := "failed to delete a detected repost message"
-	messages.ExpireMessage(p.bot, p.ctx.Session, msg, warning)
+	dgoutils.ExpireMessage(p.bot, p.ctx.Session, msg)
 
 	return nil
 }

--- a/post/post.go
+++ b/post/post.go
@@ -8,7 +8,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/VTGare/boe-tea-go/artworks"
 	"github.com/VTGare/boe-tea-go/artworks/twitter"
@@ -114,7 +113,7 @@ func (p *Post) Send() ([]*cache.MessageInfo, error) {
 			}
 		}
 
-		err := p.sendReposts(guild, res.Reposts, 15*time.Second)
+		err := p.sendReposts(res.Reposts)
 		if err != nil {
 			log.Warn("failed to send reposts")
 		}
@@ -352,7 +351,7 @@ func (p *Post) fetch(guild *store.Guild, channelID string) (*fetchResult, error)
 	return res, nil
 }
 
-func (p *Post) sendReposts(guild *store.Guild, reposts []*repost.Repost, timeout time.Duration) error {
+func (p *Post) sendReposts(reposts []*repost.Repost) error {
 	locale := messages.RepostEmbed()
 
 	eb := embeds.NewBuilder()
@@ -377,20 +376,8 @@ func (p *Post) sendReposts(guild *store.Guild, reposts []*repost.Repost, timeout
 		return fmt.Errorf("failed to send message to discord: %w", err)
 	}
 
-	go func() {
-		time.Sleep(timeout)
-		err := p.ctx.Session.ChannelMessageDelete(msg.ChannelID, msg.ID)
-		if err != nil {
-			log := p.bot.Log.With(
-				"guild_id", guild.ID,
-				"channel_id", msg.ChannelID,
-				"message_id", msg.ID,
-				"error", err,
-			)
-
-			log.Warn("failed to delete a detected repost message")
-		}
-	}()
+	warning := "failed to delete a detected repost message"
+	messages.ExpireMessage(p.bot, p.ctx.Session, msg, warning)
 
 	return nil
 }


### PR DESCRIPTION
Added ExpireMessage function used by Artwork Error Messages and Repost Messages.

Boe Tea checks url of Pixiv's error image and posts its own error message instead.